### PR TITLE
Update SFTA.au3 - #INTERNAL_USE_ONLY#

### DIFF
--- a/Scripts/SFTA/SFTA.au3
+++ b/Scripts/SFTA/SFTA.au3
@@ -69,7 +69,7 @@ EndFunc   ;==>_SFTA
 #EndRegion Public Funcions
 
 
-#Region Private Functions
+#Region #INTERNAL_USE_ONLY#
 Func __FTA_GenerateProgIdHash($sProgId, $sExtension)
 	Local $sExperienceString = __FTA_GetExperienceString()
 	Local $sDateTime = __FTA_GenerateDateTime()
@@ -260,4 +260,4 @@ Func __FTA_Base64Encode($input)
 
 EndFunc   ;==>__FTA_Base64Encode
 
-#EndRegion Private Functions
+#EndRegion #INTERNAL_USE_ONLY#


### PR DESCRIPTION
There is no things like private functions in AutoIt but can be called Internal this mean that users should not use them for the reason that they are only helper function to the "main" function 

So in relation to AutoIt Standard UDF conventions, they can be called 
#INTERNAL_USE_ONLY#